### PR TITLE
Fix PWA launch: bundle theme CSS and make service worker URLs base-safe

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0ea5e9" />
     <title>Budget Calendar</title>
-    <!-- Custom Theme Styles -->
-    <link rel="stylesheet" href="/src/themes.css" />
+    <!-- Custom Theme Styles are imported in src/main.tsx so Vite bundles them -->
     <!-- PWA -->
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" href="/icons/icon-192.png" />

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,11 @@
-const VERSION = 'v2';
+const VERSION = 'v3';
 const CACHE_NAME = `budget-cal-${VERSION}`;
 const CORE_ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest',
-  '/icons/icon-192.png',
-  '/icons/icon-512.png',
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './icons/icon-192.png',
+  './icons/icon-512.png',
 ];
 
 function cacheCoreAssets() {
@@ -65,16 +65,16 @@ self.addEventListener('fetch', event => {
       fetch(request)
         .then(response => {
           cacheResponse(request, response.clone());
-          cacheResponse('/', response.clone());
-          cacheResponse('/index.html', response.clone());
+          cacheResponse('./', response.clone());
+          cacheResponse('./index.html', response.clone());
           return response;
         })
         .catch(async () => {
-          const cached = (await caches.match(request)) || (await caches.match('/'));
+          const cached = (await caches.match(request)) || (await caches.match('./'));
           if (cached) {
             return cached;
           }
-          return caches.match('/index.html');
+          return caches.match('./index.html');
         })
     );
     return;
@@ -93,4 +93,3 @@ self.addEventListener('fetch', event => {
     })
   );
 });
-

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './themes.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -16,7 +17,8 @@ if (
   import.meta.env.PROD
 ) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(error => {
+    const swUrl = `${import.meta.env.BASE_URL}sw.js`;
+    navigator.serviceWorker.register(swUrl).catch(error => {
       console.error('[serviceWorker.register] failed', error);
     });
   });


### PR DESCRIPTION
### Motivation
- Adding theme CSS and PWA assets caused the app to fail to launch in production due to mismatched asset paths and service worker scope issues. 
- `index.html` referenced `/src/themes.css`, which is a source path that is not guaranteed to exist in the built/deployed output and can break PWA launch. 
- Absolute service worker and cache paths can fail when the app is served from a non-root `BASE_URL` or different deployment scope. 

### Description
- Removed the direct `<link rel="stylesheet" href="/src/themes.css" />` from `index.html` and added a note that theme styles are bundled from app code. 
- Imported `themes.css` from `src/main.tsx` so Vite will include the theme stylesheet in production builds via the normal bundling process (`import './themes.css'`). 
- Updated service worker registration in `src/main.tsx` to use `import.meta.env.BASE_URL` when registering the script (`const swUrl = `${import.meta.env.BASE_URL}sw.js``). 
- Hardened `public/sw.js` by making cache asset entries and navigation fallback use relative scope-safe paths (`'./'`, `'./index.html'`, etc.) and bumped the cache `VERSION` to `v3` so clients pick up the new behavior. 

### Testing
- Ran `npm run build` (Vite build) and the command completed successfully with production artifacts emitted. 
- Verified the built `dist/index.html` no longer contains a `/src/themes.css` reference and includes bundled assets, confirming the theme CSS is bundled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe6103aac832cad06ad09c667eacc)